### PR TITLE
idna 3.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.2" %}
+{% set version = "3.3" %}
 
 package:
   name: idna
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/i/idna/idna-{{ version }}.tar.gz
-  sha256: 467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3
+  sha256: 9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
 
 requirements:
   host:
-    - python >=3.5
+    - python
     - pip
     - wheel
     - setuptools
@@ -29,6 +29,7 @@ test:
     - idna.compat
   requires:
     - pip
+    - python <3.10
   commands:
     - pip check
 


### PR DESCRIPTION
Update idna to 3.3

Version change: bump version number from 3.2 to 3.3
Bug Tracker: new open issues https://github.com/kjd/idna/issues
Changelog: https://github.com/kjd/idna/blob/v3.3/HISTORY.rst
Upstream setup.py:  https://github.com/kjd/idna/blob/v3.3/setup.py

The package idna is mentioned inside the packages:
anyio | docker-py | email-validator | httpx | hyperlink | idna_ssl | libidn11 | moto | pycares | requests | rfc3986 | trio | trustme | twisted | urllib3 | yarl |

Actions:
1. Fix python

Result:
- all-succeeded